### PR TITLE
Bypass Warning when Compiling on Mac from Noir

### DIFF
--- a/barretenberg/src/aztec/CMakeLists.txt
+++ b/barretenberg/src/aztec/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-add_compile_options(-Werror -Wall -Wextra -Wconversion -Wsign-conversion -Wno-deprecated -Wno-tautological-compare -Wfatal-errors)
+add_compile_options(-Werror -Wall -Wextra -Wconversion -Wsign-conversion -Wno-deprecated -Wno-tautological-compare -Wfatal-errors -Wno-unused-but-set-variable)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wno-unguarded-availability-new -Wno-c99-extensions -fconstexpr-steps=100000000)


### PR DESCRIPTION
Env: ARM-based macOS

Compiling with `bootstrap.sh` locally works fine, but through Noir's [`build.rs`](https://github.com/noir-lang/aztec-connect/blob/kw/noir-dsl/barretenberg_wrapper/build.rs) gives:
```
/Users/…/noir/target/release/build/barretenberg_wrapper-4a960280e5361b48/out/build/_deps/leveldb-src/util/cache.cc:129:14: fatal error: variable 'count' set but not used [-Wunused-but-set-variable]
      uint32_t count = 0;
               ^
```
(which doesn't make sense, as the var `count` is used merely a few lines down in the file)

As `unused-but-set-variable` is a warning by nature that is only treated as a fatal error here, adding the flag `-Wno-unused-but-set-variable` bypasses the type of warning and warrants successful compilations even from Noir.