### PR TITLE
Fixed errors compiling barretenberg on Fedora 36 with clang 14

### DIFF
--- a/barretenberg/src/aztec/crypto/blake2s/blake2s.hpp
+++ b/barretenberg/src/aztec/crypto/blake2s/blake2s.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stddef.h>
 #include <vector>
 
 namespace blake2 {

--- a/barretenberg/src/aztec/crypto/pedersen/sidon_set/sidon_set.hpp
+++ b/barretenberg/src/aztec/crypto/pedersen/sidon_set/sidon_set.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <vector>
+#include <algorithm>
 
 #include <numeric/uintx/uintx.hpp>
 #include <ecc/fields/field.hpp>

--- a/barretenberg/src/aztec/crypto/schnorr/multisig.hpp
+++ b/barretenberg/src/aztec/crypto/schnorr/multisig.hpp
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <utility>
+#include <algorithm>
 
 #include "schnorr.hpp"
 #include "proof_of_possession.hpp"

--- a/barretenberg/src/aztec/ecc/groups/element_impl.hpp
+++ b/barretenberg/src/aztec/ecc/groups/element_impl.hpp
@@ -154,7 +154,7 @@ constexpr void element<Fq, Fr, T>::self_mixed_add_or_sub(const affine_element<Fq
             return;
         }
     } else {
-        const bool edge_case_trigger = x.is_msb_set() | other.x.is_msb_set();
+        const bool edge_case_trigger = x.is_msb_set() || other.x.is_msb_set();
         if (edge_case_trigger) {
             if (x.is_msb_set()) {
                 conditional_negate_affine(other, *(affine_element<Fq, Fr, T>*)this, predicate);
@@ -246,7 +246,7 @@ constexpr element<Fq, Fr, T> element<Fq, Fr, T>::operator+=(const affine_element
             return *this;
         }
     } else {
-        const bool edge_case_trigger = x.is_msb_set() | other.x.is_msb_set();
+        const bool edge_case_trigger = x.is_msb_set() || other.x.is_msb_set();
         if (edge_case_trigger) {
             if (x.is_msb_set()) {
                 *this = { other.x, other.y, Fq::one() };

--- a/barretenberg/src/aztec/plonk/composer/plookup_composer.hpp
+++ b/barretenberg/src/aztec/plonk/composer/plookup_composer.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include "composer_base.hpp"
 #include "plookup_tables/plookup_tables.hpp"
+#include <optional>
+#include <algorithm>
 
 namespace waffle {
 


### PR DESCRIPTION
Had a few issues compiling barretenberg on my system...

```
Fedora 36 (5.19.16-200.fc36.x86_6)

$ c++ --version
c++ (GCC) 12.2.1 20220819 (Red Hat 12.2.1-2)

$ cmake --version
cmake version 3.22.2

$ clang --version
clang version 14.0.5 (Fedora 14.0.5-1.fc36)
Target: x86_64-redhat-linux-gnu

-- Toolchain: x86_64-linux-clang
```

Changes:
- Added missing includes.
- Updated bitwise operation on boolean.

---

Additionally, my Google tests fail with the following error:
```
CMake Error at /usr/share/cmake/Modules/GoogleTestAddTests.cmake:83 (message):
  Error running test executable.

    Path: '/home/jeremy/Repositories/aztec-connect/barretenberg/build/bin/rollup_proofs_root_rollup_tests'
    Result: Illegal instruction
    Output:
      

Call Stack (most recent call first):
  /usr/share/cmake/Modules/GoogleTestAddTests.cmake:179 (gtest_discover_tests_impl)

CMake Error at /usr/share/cmake/Modules/GoogleTestAddTests.cmake:83 (message):
  Error running test executable.

    Path: '/home/jeremy/Repositories/aztec-connect/barretenberg/build/bin/rollup_proofs_root_verifier_tests'
    Result: Illegal instruction
    Output:
      

Call Stack (most recent call first):
  /usr/share/cmake/Modules/GoogleTestAddTests.cmake:179 (gtest_discover_tests_impl)
```

The binary files `rollup_proofs_root_rollup_tests` and `rollup_proofs_root_verifier_tests` do not exist.

I can fix this by altering the following line:
```
barretenberg/cmake/module.cmake:43

From...

if(TESTING AND TEST_SOURCE_FILES)

To...

if(TESTING AND TEST_SOURCE_FILES AND (NOT MODULE_NAME MATCHES "rollup_proofs_root_rollup") AND (NOT MODULE_NAME MATCHES "rollup_proofs_root_verifier"))
```
I have no idea if this is acceptable or why this is happening so I have excluded the above change this from this PR.

Any thoughts on this would be much appreciated.