### PR TITLE
stage <- Euler redemption

### DIFF
--- a/yarn-project/falafel/src/tx_receiver/tx_receiver.ts
+++ b/yarn-project/falafel/src/tx_receiver/tx_receiver.ts
@@ -99,10 +99,12 @@ export class TxReceiver {
           }
           if (txType === TxType.DEFI_DEPOSIT) {
             const { bridgeCallData } = new DefiDepositProofData(proof);
-            const { outputAssetIdA, outputAssetIdB } = bridgeCallData;
+            const { inputAssetIdA, outputAssetIdA, outputAssetIdB } = bridgeCallData;
             if (allowedBridgeCallData.includes(bridgeCallData.toString())) {
               shouldReject = false;
             } else if (outputAssetIdB === undefined && [0, 1].includes(outputAssetIdA)) {
+              shouldReject = false;
+            } else if ([5, 6, 7].includes(inputAssetIdA)) {
               shouldReject = false;
             } else {
               this.log(


### PR DESCRIPTION
Allow exits with euler assets on any bridge. Useful for redemption without having to specify the bridge across networks. 