### PR TITLE
Fix/code

### DIFF
--- a/aztec-connect-cpp/dockerfiles/Dockerfile.wasm-linux-clang
+++ b/aztec-connect-cpp/dockerfiles/Dockerfile.wasm-linux-clang
@@ -1,5 +1,6 @@
 FROM ubuntu:focal AS builder
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential wget git libssl-dev cmake curl binaryen
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y binutils build-essential cmake curl git libssl-dev wget
 RUN curl https://wasmtime.dev/install.sh -sSf | bash /dev/stdin --version v0.25.0
 WORKDIR /usr/src/aztec-connect-cpp/src
 RUN curl -s -L https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz | tar zxfv -

--- a/aztec-connect-cpp/dockerfiles/Dockerfile.x86_64-linux-clang
+++ b/aztec-connect-cpp/dockerfiles/Dockerfile.x86_64-linux-clang
@@ -4,10 +4,10 @@ RUN apk update \
     && apk add --no-cache \
         build-base \
         clang \
-        cmake \
-        git \
-        curl \
-        perl
+    cmake \
+    curl \
+    git \
+    perl
 # libomp is not available in alpine by default. Download and build.
 RUN git clone -b release/10.x --depth 1 https://github.com/llvm/llvm-project.git \
   && cd llvm-project && mkdir build-openmp && cd build-openmp \


### PR DESCRIPTION
# Fix: Sorted package names alphanumerically in Dockerfiles

## Changes
1. **Sorted package names in `Dockerfile.wasm-linux-clang`**:
   - Rearranged package names in the `RUN apt-get install` command.

     - **Before**:
       ```dockerfile
       RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
           apt-get install -y build-essential wget git libssl-dev cmake curl binutils
       ```
     - **After**:
       ```dockerfile
       RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
           apt-get install -y binutils build-essential cmake curl git libssl-dev wget
       ```

2. **Sorted package names in `Dockerfile.x86_64-linux-clang`**:
   - Rearranged package names in the `RUN apk add` command.

     - **Before**:
       ```dockerfile
       RUN apk add --no-cache \
           build-base \
           clang \
           cmake \
           git \
           curl \
           perl
       ```
     - **After**:
       ```dockerfile
       RUN apk add --no-cache \
           build-base \
           clang \
           cmake \
           curl \
           git \
           perl
       ```

## Purpose
- Improved readability and maintainability of Dockerfiles by sorting package names alphabetically.
- Resolved SonarQube warnings regarding unsorted package names.
